### PR TITLE
Passing Array instead of Buffer to x11hash.digest

### DIFF
--- a/lib/crypto/hash.js
+++ b/lib/crypto/hash.js
@@ -29,6 +29,7 @@ Hash.sha256sha256 = function(buf) {
 
 Hash.x11 = function(buf) {
   $.checkArgument(BufferUtil.isBuffer(buf));
+  buf = [].slice.call(buf, 0);
   return new Buffer(x11hash.digest(buf, 1, 2));
 };
 


### PR DESCRIPTION
This fixes the crash on _insight-pac-api_ endpoint `/block/:blockhash`.